### PR TITLE
Modification needed for Post-Kernel 5.1 usage

### DIFF
--- a/waveshare35a.dts
+++ b/waveshare35a.dts
@@ -54,7 +54,7 @@
 				fps = <30>;
 				buswidth = <8>;
 				regwidth = <16>;
-				reset-gpios = <&gpio 25 0>;
+				reset-gpios = <&gpio 25 1>;
 				dc-gpios = <&gpio 24 0>;
 				debug = <0>;
 
@@ -81,7 +81,7 @@
 				spi-max-frequency = <2000000>;
 				interrupts = <17 2>; /* high-to-low edge triggered */
 				interrupt-parent = <&gpio>;
-				pendown-gpio = <&gpio 17 0>;
+				pendown-gpio = <&gpio 17 1>;
 				ti,x-plate-ohms = /bits/ 16 <60>;
 				ti,pressure-max = /bits/ 16 <255>;
 			};


### PR DESCRIPTION
As per private conversation with Phil Reid:

"Prior to the switch to gpiod polarity definitions in the dts file where not being honoured."

(confirmed working with the fbtft driver from Kernel 5.4, once CONFIG_SPI_BCM2835AUX=m is set in the kernel config.)